### PR TITLE
Updating package.json to use local binaries

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,9 +60,9 @@
   },
   "scripts": {
     "develop": "NODE_ENV=development node server.js",
-    "test": "jest",
-    "build": "NODE_ENV=production webpack --progress --config webpack.config.prod",
-    "build:staging": "NODE_ENV=development webpack --progress --config webpack.config.staging",
+    "test": "./node_modules/.bin/jest",
+    "build": "NODE_ENV=production ./node_modules/.bin/webpack --progress --config webpack.config.prod",
+    "build:staging": "NODE_ENV=development ./node_modules/.bin/webpack --progress --config webpack.config.staging",
     "publish": "./scripts/publish.sh"
   },
   "repository": {


### PR DESCRIPTION
Use the binaries installed in `./node_modules/.bin` instead of those
that are installed globally.  This eliminates the requirements that
all developers have globally installed things like `webpack`
and `jest`.  It also eliminates the possibility of errors arising
because people are using different versions of these tools.