### PR TITLE
Adding default route in development server

### DIFF
--- a/server.js
+++ b/server.js
@@ -22,7 +22,7 @@ app.use(function(req, res, next) {
   return next();
 });
 
-app.get("/", function(req, res) {
+app.get("*", function(req, res) {
   res.sendFile(__dirname + '/index.html');
 });
 


### PR DESCRIPTION
If I refresh the page when running `npm run develop`, I get
an error saying "Cannot get `/<route>`".  Adding a `*` route
so that the server fetches the page and then react-router can
decide what to do:

![Imgur](http://i.imgur.com/LhatjvQ.png)
